### PR TITLE
Mantid Turret 

### DIFF
--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -106,36 +106,36 @@
 	hitchance_mod = 100 //this and dispersion likely isn't needed, but, whatever
 	distance_falloff = 0.25
 	dispersion = 0
-
+	
 /obj/machinery/porta_turret/mantid
-    name = "Anti-personnel battery"
-    desc = "A sleek, menacing turret of Alien origin."
-    use_power = 0 //Not optimal, but they lose power on each Z-level transfer. DM has forced my hand.
-    maxhealth = 300
-    health = 300
-    auto_repair = 1
-    enabled = 1
-    ailock = 1
-    lethal = 1
-    check_synth     = 0
-    check_access = 1
-    check_arrest = 0
-    check_records = 0
-    shot_delay = 10
-    check_weapons = 0
-    check_anomalies = 1
-    installation = /obj/item/weapon/gun/energy/turret/skrell
-    color = "#7851a9"
-    req_access = list("ACCESS_ASCENT")
+	name = "Anti-personnel battery"
+	desc = "A sleek, menacing turret of Ascent origin."
+	use_power = 0 //Not optimal, but they lose power on each Z-level transfer. DM has forced my hand.
+	maxhealth = 300
+	health = 300
+	auto_repair = 1
+	enabled = 1
+	ailock = 1
+	lethal = 1
+	check_synth     = 0
+	check_access = 1
+	check_arrest = 0
+	check_records = 0
+	shot_delay = 10
+	check_weapons = 0
+	check_anomalies = 1
+	installation = /obj/item/weapon/gun/energy/turret/skrell
+	color = "#7851a9"
+	req_access = list("ACCESS_ASCENT")
 
 /obj/item/weapon/gun/energy/turret/skrell
-    accuracy = 1
-    projectile_type = /obj/item/projectile/beam/particleadv
+	accuracy = 1
+	projectile_type = /obj/item/projectile/beam/particleadv
 
 /obj/item/projectile/beam/pulse/skrell/heavy/turret
-    hitchance_mod = 100 //this and dispersion likely isn't needed, but, whatever
-    distance_falloff = 0.25
-    dispersion = 0
+	hitchance_mod = 100 //this and dispersion likely isn't needed, but, whatever
+	distance_falloff = 0.25
+	dispersion = 0
 
 /obj/machinery/porta_turret/ssv/vox
 


### PR DESCRIPTION


If I didn't fuck anything up this should be a clone of the SSV Turret that can be used by the Ascent faction on their ship and elsewhere. Complete with particle lance beam instead of lasers and a neat purple paint job.

*Adds a new turret to machinery/portable_turret.dm
*(Hopefully) fixed indenting errors and changed description of turret.